### PR TITLE
Django 4 compat

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,6 +24,7 @@ repos:
       - id: check-added-large-files
       - id: check-ast  # Is it valid Python?
       - id: debug-statements  # Check for debugger imports and py37+ breakpoint() calls
+      - id: check-merge-conflict
 
   - repo: https://github.com/editorconfig-checker/editorconfig-checker.python
     rev: 2.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [In Development] - Unreleased
 
+
+## [1.4.0] - 2022-01-28
+
 ### Fixed
 
 - [Compatibility] AA 3.x / Django 4 :: ImportError: cannot import name

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [In Development] - Unreleased
 
 
-## [1.4.0] - 2022-01-28
+## [1.4.0] - 2022-02-28
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 
+## [In Development] - Unreleased
+
+### Fixed
+
+- [Compatibility] AA 3.x / Django 4 :: ImportError: cannot import name
+  'ugettext_lazy' from 'django.utils.translation'
+
+
 ## [1.3.0] - 2022-01-02
 
 ### Added

--- a/esistatus/__init__.py
+++ b/esistatus/__init__.py
@@ -4,5 +4,5 @@ a couple of variable to use throughout the app
 
 default_app_config: str = "esistatus.apps.AaEsiStatusConfig"
 
-__version__ = "1.3.0"
+__version__ = "1.4.0"
 __title__ = "ESI Status"

--- a/esistatus/auth_hooks.py
+++ b/esistatus/auth_hooks.py
@@ -3,7 +3,7 @@ hook into AA
 """
 
 # Django
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 # Alliance Auth
 from allianceauth import hooks

--- a/testauth/urls.py
+++ b/testauth/urls.py
@@ -1,10 +1,10 @@
 # Django
-from django.conf.urls import include, url
+from django.urls import include, re_path
 
 # Alliance Auth
 from allianceauth import urls
 
 urlpatterns = [
     # Alliance Auth URLs
-    url(r"", include(urls)),
+    re_path(r"", include(urls)),
 ]


### PR DESCRIPTION
## Description

### Fixed

- [Compatibility] AA 3.x / Django 4 :: ImportError: cannot import name
  'ugettext_lazy' from 'django.utils.translation'


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not
  work as expected)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
