### PR TITLE
[CHANGE] Use Bootstraps `text-bg-*` classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,11 @@ Section Order:
 ### Security
 -->
 
+### Changed
+
+- Use Bootstraps `text-bg-*` classes for the status colors to leverage Bootstraps
+  native background/text contrast handling
+
 ## [2.5.2] - 2025-03-24
 
 ### Added

--- a/esistatus/templates/esistatus/partials/endpoints.html
+++ b/esistatus/templates/esistatus/partials/endpoints.html
@@ -1,6 +1,6 @@
 <div class="col-md-4 mb-3 mb-md-0">
     <div class="card card-{{ status }}-esi-endpoints">
-        <div class="card-header bg-{% if status == 'red' %}danger{% elif status == 'yellow' %}warning{% else %}success{% endif %}">
+        <div class="card-header text-bg-{% if status == 'red' %}danger{% elif status == 'yellow' %}warning{% else %}success{% endif %}">
             <div class="card-title text-white text-center mb-0">
                 {{ title|title }}
                 <i


### PR DESCRIPTION
## Description

### Changed

- Use Bootstraps `text-bg-*` classes for the status colors to leverage Bootstraps
  native background/text contrast handling

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
