### PR TITLE
[RELEASE] v2.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ Section Order:
 ### Security
 -->
 
+## [2.8.0] - 2025-07-21
+
 ### Added
 
 - Internal URL prefix

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Restart your supervisor services for AA.
 Add the app to your `conf/requirements.txt`:
 
 ```text
-aa-esi-status==2.7.0
+aa-esi-status==2.8.0
 ```
 
 #### Step 2: Update Your AA Settings<a name="step-2-update-your-aa-settings-1"></a>
@@ -193,7 +193,7 @@ To update your existing installation of AA ESI Status, all you need to do is to
 update the respective line in your `conf/requirements.txt` file to the latest version.
 
 ```text
-aa-esi-status==2.7.0
+aa-esi-status==2.8.0
 ```
 
 Now rebuild your containers:

--- a/esistatus/__init__.py
+++ b/esistatus/__init__.py
@@ -8,7 +8,7 @@ import requests
 # Django
 from django.utils.translation import gettext_lazy as _
 
-__version__ = "2.7.0"
+__version__ = "2.8.0"
 __title__ = _("ESI Status")
 
 __package_name__ = "aa-esi-status"

--- a/esistatus/locale/django.pot
+++ b/esistatus/locale/django.pot
@@ -6,9 +6,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: AA ESI Status 2.6.0\n"
+"Project-Id-Version: AA ESI Status 2.8.0\n"
 "Report-Msgid-Bugs-To: https://github.com/ppfeufer/aa-esi-status/issues\n"
-"POT-Creation-Date: 2025-05-27 06:14+0200\n"
+"POT-Creation-Date: 2025-07-21 10:57+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -32,44 +32,44 @@ msgstr ""
 msgid "Can access this app"
 msgstr ""
 
-#: esistatus/templates/esistatus/index.html:8
+#: esistatus/templates/esistatus/index.html:10
+msgid "Loading …"
+msgstr ""
+
+#: esistatus/templates/esistatus/index.html:12
+msgid "Loading ESI status …"
+msgstr ""
+
 #: esistatus/templates/esistatus/partials/dashboard-widget/esi-status.html:9
+#: esistatus/templates/esistatus/partials/index/esi-status.html:5
 msgid "Red endpoints"
 msgstr ""
 
-#: esistatus/templates/esistatus/index.html:9
 #: esistatus/templates/esistatus/partials/dashboard-widget/esi-status.html:10
+#: esistatus/templates/esistatus/partials/index/esi-status.html:6
 msgid ""
 "Red endpoints have a good chance of not responding at all or being "
 "completely unavailable."
 msgstr ""
 
-#: esistatus/templates/esistatus/index.html:12
 #: esistatus/templates/esistatus/partials/dashboard-widget/esi-status.html:13
+#: esistatus/templates/esistatus/partials/index/esi-status.html:10
 msgid "Yellow endpoints"
 msgstr ""
 
-#: esistatus/templates/esistatus/index.html:13
 #: esistatus/templates/esistatus/partials/dashboard-widget/esi-status.html:14
+#: esistatus/templates/esistatus/partials/index/esi-status.html:11
 msgid "Yellow endpoints have a good chance of being slow or returning errors."
 msgstr ""
 
-#: esistatus/templates/esistatus/index.html:16
 #: esistatus/templates/esistatus/partials/dashboard-widget/esi-status.html:17
+#: esistatus/templates/esistatus/partials/index/esi-status.html:15
 msgid "Green endpoints"
 msgstr ""
 
-#: esistatus/templates/esistatus/index.html:17
 #: esistatus/templates/esistatus/partials/dashboard-widget/esi-status.html:18
+#: esistatus/templates/esistatus/partials/index/esi-status.html:16
 msgid "Green endpoints are responding as expected."
-msgstr ""
-
-#: esistatus/templates/esistatus/index.html:22
-msgid "Couldn't read the ESI status."
-msgstr ""
-
-#: esistatus/templates/esistatus/index.html:26
-msgid "Error Message"
 msgstr ""
 
 #: esistatus/templates/esistatus/partials/dashboard-widget/esi-status.html:24
@@ -88,4 +88,12 @@ msgstr ""
 
 #: esistatus/templates/esistatus/partials/footer/app-translation-footer.html:8
 msgid "Join our team of translators!"
+msgstr ""
+
+#: esistatus/templates/esistatus/partials/index/esi-status.html:21
+msgid "Couldn't read the ESI status."
+msgstr ""
+
+#: esistatus/templates/esistatus/partials/index/esi-status.html:25
+msgid "Error Message"
 msgstr ""


### PR DESCRIPTION
## [2.8.0] - 2025-07-21

### Added

- Internal URL prefix

### Changed

- Use an Ajax call to load the ESI status instead of loading it directly in the template