### PR TITLE
[RELEASE] v3.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,13 +32,21 @@ Section Order:
 ### Deprecated
 ### Removed
 ### Security
+### Miscellaneous
 -->
 
 <!-- Your changes go here -->
 
+## [3.3.5] - 2026-05-05
+
 ### Changed
 
 - Use headers for requests to ESI instead of query parameters to submit the ESI compatibility date
+- Translations updated
+
+### Miscellaneous
+
+- Ready for Alliance Auth v5
 
 ## [3.3.4] - 2026-03-11
 
@@ -735,7 +743,8 @@ CELERYBEAT_SCHEDULE["ESI Status :: Update"] = {
 [3.3.2]: https://github.com/ppfeufer/aa-esi-status/compare/v3.3.1...v3.3.2 "v3.3.2"
 [3.3.3]: https://github.com/ppfeufer/aa-esi-status/compare/v3.3.2...v3.3.3 "v3.3.3"
 [3.3.4]: https://github.com/ppfeufer/aa-esi-status/compare/v3.3.3...v3.3.4 "v3.3.4"
-[in development]: https://github.com/ppfeufer/aa-esi-status/compare/v3.3.4...HEAD "In Development"
+[3.3.5]: https://github.com/ppfeufer/aa-esi-status/compare/v3.3.4...v3.3.5 "v3.3.5"
+[in development]: https://github.com/ppfeufer/aa-esi-status/compare/v3.3.5...HEAD "In Development"
 [keep a changelog]: http://keepachangelog.com/ "Keep a Changelog"
 [readme]: https://github.com/ppfeufer/aa-esi-status/blob/main/README.md "README.md"
 [semantic versioning]: http://semver.org/ "Semantic Versioning"

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Make sure you're in the virtual environment (venv) of your Alliance Auth install
 Then install the latest version:
 
 ```shell
-pip install aa-esi-status==3.3.4
+pip install aa-esi-status==3.3.5
 ```
 
 #### Step 2: Update Your AA Settings<a name="step-2-update-your-aa-settings"></a>
@@ -132,7 +132,7 @@ Restart your supervisor services for AA.
 Add the app to your `conf/requirements.txt`:
 
 ```text
-aa-esi-status==3.3.4
+aa-esi-status==3.3.5
 ```
 
 #### Step 2: Update Your AA Settings<a name="step-2-update-your-aa-settings-1"></a>
@@ -211,7 +211,7 @@ Then run the following commands from your AA project directory (the one that
 contains `manage.py`).
 
 ```shell
-pip install aa-esi-status==3.3.4
+pip install aa-esi-status==3.3.5
 python manage.py collectstatic
 python manage.py migrate
 ```
@@ -224,7 +224,7 @@ To update your existing installation of AA ESI Status, all you need to do is to
 update the respective line in your `conf/requirements.txt` file to the latest version.
 
 ```text
-aa-esi-status==3.3.4
+aa-esi-status==3.3.5
 ```
 
 Now rebuild your containers:

--- a/esistatus/__init__.py
+++ b/esistatus/__init__.py
@@ -8,7 +8,7 @@ import requests
 # Django
 from django.utils.translation import gettext_lazy as _
 
-__version__ = "3.3.4"
+__version__ = "3.3.5"
 __title__ = "ESI Status"
 __title_translated__ = _("ESI Status")
 

--- a/esistatus/locale/django.pot
+++ b/esistatus/locale/django.pot
@@ -6,9 +6,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: AA ESI Status 3.3.4\n"
+"Project-Id-Version: AA ESI Status 3.3.5\n"
 "Report-Msgid-Bugs-To: https://github.com/ppfeufer/aa-esi-status/issues\n"
-"POT-Creation-Date: 2026-03-11 12:49+0100\n"
+"POT-Creation-Date: 2026-05-05 13:58+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"


### PR DESCRIPTION
## [3.3.5] - 2026-05-05

### Changed

- Use headers for requests to ESI instead of query parameters to submit the ESI compatibility date
- Translations updated

### Miscellaneous

- Ready for Alliance Auth v5