### PR TITLE
[RELEASE] v4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ Section Order:
 
 <!-- Your changes go here -->
 
+## [4.0.0] - 2026-06-07
+
 > [!IMPORTANT]
 >
 > **This version needs Alliance Auth v5!**
@@ -765,7 +767,8 @@ CELERYBEAT_SCHEDULE["ESI Status :: Update"] = {
 [3.3.4]: https://github.com/ppfeufer/aa-esi-status/compare/v3.3.3...v3.3.4 "v3.3.4"
 [3.3.5]: https://github.com/ppfeufer/aa-esi-status/compare/v3.3.4...v3.3.5 "v3.3.5"
 [3.4.0]: https://github.com/ppfeufer/aa-esi-status/compare/v3.3.5...v3.4.0 "v3.4.0"
-[in development]: https://github.com/ppfeufer/aa-esi-status/compare/v3.4.0...HEAD "In Development"
+[4.0.0]: https://github.com/ppfeufer/aa-esi-status/compare/v3.4.0...v4.0.0 "v4.0.0"
+[in development]: https://github.com/ppfeufer/aa-esi-status/compare/v4.0.0...HEAD "In Development"
 [keep a changelog]: http://keepachangelog.com/ "Keep a Changelog"
 [readme]: https://github.com/ppfeufer/aa-esi-status/blob/main/README.md "README.md"
 [semantic versioning]: http://semver.org/ "Semantic Versioning"

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Make sure you're in the virtual environment (venv) of your Alliance Auth install
 Then install the latest version:
 
 ```shell
-pip install aa-esi-status==3.4.0
+pip install aa-esi-status==4.0.0
 ```
 
 #### Step 2: Update Your AA Settings<a name="step-2-update-your-aa-settings"></a>
@@ -132,7 +132,7 @@ Restart your supervisor services for AA.
 Add the app to your `conf/requirements.txt`:
 
 ```text
-aa-esi-status==3.4.0
+aa-esi-status==4.0.0
 ```
 
 #### Step 2: Update Your AA Settings<a name="step-2-update-your-aa-settings-1"></a>
@@ -211,7 +211,7 @@ Then run the following commands from your AA project directory (the one that
 contains `manage.py`).
 
 ```shell
-pip install aa-esi-status==3.4.0
+pip install aa-esi-status==4.0.0
 python manage.py collectstatic
 python manage.py migrate
 ```
@@ -224,7 +224,7 @@ To update your existing installation of AA ESI Status, all you need to do is to
 update the respective line in your `conf/requirements.txt` file to the latest version.
 
 ```text
-aa-esi-status==3.4.0
+aa-esi-status==4.0.0
 ```
 
 Now rebuild your containers:

--- a/esistatus/__init__.py
+++ b/esistatus/__init__.py
@@ -8,7 +8,7 @@ import requests
 # Django
 from django.utils.translation import gettext_lazy as _
 
-__version__ = "3.4.0"
+__version__ = "4.0.0"
 __title__ = "ESI Status"
 __title_translated__ = _("ESI Status")
 


### PR DESCRIPTION
## [4.0.0] - 2026-06-07

> [!IMPORTANT]
> 
> **This version needs Alliance Auth v5!**
> 
> Please make sure to update your Alliance Auth instance **before** you install this
> version, otherwise an update to Alliance Auth will be pulled in unsupervised.

### Removed

- Support for Alliance Auth v4